### PR TITLE
Replace "list" with "menu" for the Menu CSS module

### DIFF
--- a/src/menus/tests/manual/menus.html
+++ b/src/menus/tests/manual/menus.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset='utf-8'>
     <meta name="viewport" content="width = device-width">
-    <title>List CSS</title>
+    <title>Menus CSS</title>
     <link rel="stylesheet" type="text/css" href="../../../../build/menus-min.css">
 
     <style>
@@ -45,8 +45,8 @@
 
     <div class="header y-u-1">
 
-        <h1 class="pure-u-1">Pure List CSS</h1>
-        <h2 class="pure-u">Simple styling for HTML List elements.</h2>
+        <h1 class="pure-u-1">Pure Menus CSS</h1>
+        <h2 class="pure-u">Simple styling for HTML List elements as menus.</h2>
 
     </div>
 
@@ -55,7 +55,7 @@
         <h2>Horizontal Menu</h2>
 
         <p>
-            You can mark the active list element by adding the <code>.pure-menu-selected</code> class to the list element.
+            You can mark the active menu element by adding the <code>.pure-menu-selected</code> class to the list item.
         </p>
 
         <div class="pure-menu pure-menu-open pure-menu-horizontal">


### PR DESCRIPTION
I found that we still had "list" around in a few places, so I switched it to "menu"
