### PR TITLE
Remove ridiculous `a:focus { outline: none; }` rule

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@ Pure Change History
 NEXT
 ----
 
+* Fixed accessability mistake by removing `a:focus {outline: none;}` rule from
+  `buttons-core.css`.
+
 ### Forms
 
 * (!) `.pure-help-inline` has been replaced with `.pure-form-message-inline`. We

--- a/src/buttons/css/buttons-core.css
+++ b/src/buttons/css/buttons-core.css
@@ -14,14 +14,8 @@
     user-select: none;
 }
 
-
 /* Firefox: Get rid of the inner focus border */
 .pure-button::-moz-focus-inner{
     padding: 0;
     border: 0;
 }
-
-a:focus {
-    outline: none;
-}
-


### PR DESCRIPTION
This rule should have never been here, it's one of the worst things we could have done for accessibility :(
