### PR TITLE
Distinguish between readonly and disabled inputs

### DIFF
--- a/src/forms/css/forms.css
+++ b/src/forms/css/forms.css
@@ -78,14 +78,17 @@
 .pure-form input[type="tel"][disabled],
 .pure-form input[type="color"][disabled],
 .pure-form select[disabled],
-.pure-form textarea[disabled],
-.pure-form input[readonly],
-.pure-form select[readonly],
-.pure-form textarea[readonly] {
+.pure-form textarea[disabled] {
     cursor: not-allowed;
     background-color: #eaeded;
     color: #cad2d3;
     border-color: transparent;
+}
+.pure-form input[readonly],
+.pure-form select[readonly],
+.pure-form textarea[readonly] {
+    cursor: not-allowed;
+    color: #777;
 }
 .pure-form input:focus:invalid,
 .pure-form textarea:focus:invalid,

--- a/src/forms/tests/manual/forms.html
+++ b/src/forms/tests/manual/forms.html
@@ -250,7 +250,13 @@
      <h2>Disabled Inputs</h2>
      <p>Add the disabled attribute to any form control.</p>
      <form class="pure-form">
-       <input class="pure-input-xlarge" id="disabledInput" type="text" placeholder="Disabled input here..." disabled>
+       <input class="pure-input-xlarge" id="disabledInput" type="text" placeholder="Disabled input here..." value="Foo bar baz" disabled>
+     </form>
+
+     <h2>Readonly Inputs</h2>
+     <p>Add the readonly attribute to any form control.</p>
+     <form class="pure-form">
+       <input class="pure-input-xlarge" id="readonlyInput" type="text" placeholder="Readonly input here..." value="Foo bar baz" readonly>
      </form>
 
      <h2>Rounded Form</h2>


### PR DESCRIPTION
I found readonly inputs hard to read so I modified pure to distinguish between disabled and read-only inputs. Disabled inputs are styled as before. Read-only inputs now are like normal inputs with dark-grey text.
