### PR TITLE
Change the grunt script to also buid pure rollups with base-context module

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -123,8 +123,26 @@ grunt.initConfig({
                     'build/tables-min.css'
                 ],
 
+                'build/<%= pkg.name %>-context-min.css': [
+                    'build/base-context-min.css',
+                    'build/buttons-min.css',
+                    'build/forms-min.css',
+                    'build/grids-min.css',
+                    'build/menus-min.css',
+                    'build/tables-min.css'
+                ],
+
                 'build/<%= pkg.name %>-nr-min.css': [
                     'build/base-min.css',
+                    'build/buttons-min.css',
+                    'build/forms-nr-min.css',
+                    'build/grids-nr-min.css',
+                    'build/menus-nr-min.css',
+                    'build/tables-min.css'
+                ],
+
+                'build/<%= pkg.name %>-context-nr-min.css': [
+                    'build/base-context-min.css',
                     'build/buttons-min.css',
                     'build/forms-nr-min.css',
                     'build/grids-nr-min.css',

--- a/README.md
+++ b/README.md
@@ -100,8 +100,16 @@ conventions of the files in the `build/` directory follow these rules:
 * `pure-min.css`: A rollup of all `[module]-min.css` files in the `build/` dir.
   This is a responsive roll-up of everything.
 
-* `pure-nr-min.css`: A Rollup of all modules without @media queries. This is a
+* `pure-context-min.css`: A rollup of all `[module]-min.css` files in the
+  `build/` dir with base-context-min.css instead of base-min.css. This is a
+   responsive roll-up of everything.
+
+* `pure-nr-min.css`: A rollup of all modules without @media queries. This is a
   non-responsive roll-up of everything.
+
+* `pure-context-nr-min.css`: A rollup of all modules without @media queries with
+  base-context-min.css instead of base-min.css. This is a non-responsive roll-up
+  of everything.
 
 
 [Grunt]: http://gruntjs.com/


### PR DESCRIPTION
The title says it all. With this patch, `grunt` will also build `pure-context-min.css` and `pure-context-nr-min` where base-min.css is replaced by base-context-min.css.
