### PR TITLE
revert pure-button:visited fix

### DIFF
--- a/src/buttons/css/buttons.css
+++ b/src/buttons/css/buttons.css
@@ -1,7 +1,6 @@
 /*csslint unqualified-attributes:false, outline-none:false*/
 
-.pure-button,
-.pure-button:visited {
+.pure-button {
     font-size: 100%;
     *font-size: 90%; /*IE 6/7 - To reduce IE's oversized button text*/
     *overflow: visible; /*IE 6/7 - Because of IE's overly large left/right padding on buttons */
@@ -37,6 +36,7 @@
 .pure-button:focus {
     outline: 0;
 }
+
 .pure-button-active,
 .pure-button:active {
     box-shadow: 0 0 0 1px rgba(0,0,0, 0.15) inset, 0 0 6px rgba(0,0,0, 0.20) inset;

--- a/src/buttons/tests/manual/button.html
+++ b/src/buttons/tests/manual/button.html
@@ -113,14 +113,5 @@
         <input type="button" class="pure-button pure-button-primary" value="Input Button">
         <input type="reset" class="pure-button pure-button-primary" value="Reset">
     </p>
-
-    <h2>Visited Button</h2>
-    <p>
-        A Pure Button should not inherit styles from <code>a:visited</code>. There has been some <code>a:visited</code> code inserted at the top of this page. The button below should look the same as a regular button.
-    </p>
-
-    <p>
-        <a class="pure-button" href="http://yahoo.com">Visited Pure Button</a>
-    </p>
 </body>
 </html>


### PR DESCRIPTION
Revert the addition of `.pure-button:visited` rules since they cause issues with overridden button styles. 
