### PR TITLE
Exanding the fractions those who think only in columns

### DIFF
--- a/src/grids/css/grids-units.css
+++ b/src/grids/css/grids-units.css
@@ -15,9 +15,17 @@
 .pure-u-5-8,
 .pure-u-7-8,
 .pure-u-1-12,
+.pure-u-2-12,
+.pure-u-3-12,
+.pure-u-4-12,
 .pure-u-5-12,
+.pure-u-6-12,
 .pure-u-7-12,
+.pure-u-8-12,
+.pure-u-9-12,
+.pure-u-10-12,
 .pure-u-11-12,
+.pure-u-12-12,
 .pure-u-1-24,
 .pure-u-5-24,
 .pure-u-7-24,
@@ -35,27 +43,27 @@
     text-rendering: auto;
 }
 
-.pure-u-1 {
+.pure-u-1, .pure-u-12-12 {
     width: 100%;
 }
 
-.pure-u-1-2 {
+.pure-u-1-2, .pure-u-6-12 {
     width: 50%;
 }
 
-.pure-u-1-3 {
+.pure-u-1-3, .pure-u-4-12 {
     width: 33.33333%;
 }
 
-.pure-u-2-3 {
+.pure-u-2-3, .pure-u-8-12 {
     width: 66.66666%;
 }
 
-.pure-u-1-4 {
+.pure-u-1-4, .pure-u-3-12 {
     width: 25%;
 }
 
-.pure-u-3-4 {
+.pure-u-3-4, .pure-u-9-12 {
     width: 75%;
 }
 
@@ -75,11 +83,11 @@
     width: 80%;
 }
 
-.pure-u-1-6 {
+.pure-u-1-6, .pure-u-2-12 {
     width: 16.666%;
 }
 
-.pure-u-5-6 {
+.pure-u-5-6, .pure-u-10-12 {
     width: 83.33%;
 }
 


### PR DESCRIPTION
I've run into some designers coding their portfolios and other basic websites who only think in column widths. They aren't math oriented, and thus have a harder time associating reduced fractions with column widths. This shouldn't add any bloat, and will make it more usable to those who prefer column based class notation.
