### PR TITLE
Added unminifed roll-up of everything. 'pure.css'.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,6 +114,14 @@ grunt.initConfig({
 
         all: {
             files: {
+                'build/<%= pkg.name %>.css': [
+                    'build/base.css',
+                    'build/buttons.css',
+                    'build/forms.css',
+                    'build/grids.css',
+                    'build/menus.css',
+                    'build/tables.css'
+                ],
                 'build/<%= pkg.name %>-min.css': [
                     'build/base-min.css',
                     'build/buttons-min.css',

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ conventions of the files in the `build/` directory follow these rules:
 
 * `*-min.css`: A minified file version of the files of the same name.
 
+* `pure.css`: A rollup of all `[module].css` files in the `build/` dir.
+  This is a responsive roll-up of everything.
+
 * `pure-min.css`: A rollup of all `[module]-min.css` files in the `build/` dir.
   This is a responsive roll-up of everything.
 


### PR DESCRIPTION
Hello,

An unminifed version of `pure-min.css` is helpful for people who have a build system that minifies all their css files into a single file. Of course one can add all the modules into their css directory but that would get a little bit messy.
