### PR TITLE
Fix image resizing to be proportional

### DIFF
--- a/src/grids/css/grids-r.css
+++ b/src/grids/css/grids-r.css
@@ -17,6 +17,7 @@
 
 .pure-g-r img {
     max-width: 100%;
+    height: auto;
 }
 
 @media (min-width: 980px) {


### PR DESCRIPTION
Images inside .pure-g-r when resized didn't change their height. Fix this by adding setting their height to 'auto'.

![beforeafter](https://f.cloud.github.com/assets/52677/1017185/331e17f0-0c0b-11e3-9f12-33a497268d22.jpg)
