### PR TITLE
[Fix #41] Update font stack

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -52,7 +52,7 @@ NEXT
   grids from breaking in various target environments:
 
   ```css
-  font-family: FreeSans, Arimo, Helvetica, Arial, sans-serif;
+  font-family: FreeSans, Arimo, "Droid Sans", Helvetica, Arial, sans-serif;
   ```
 
   This is a *breaking* change. If you are using any non-default font in your project,

--- a/src/grids/css/grids-core.css
+++ b/src/grids/css/grids-core.css
@@ -19,10 +19,12 @@
     Arial` to get picked up by the browser, even though Helvetica or Arial
     isn't available in that environment.
 
+    * Droid Sans: Arch Linux with Chromium 29.x.
+
     * Helvetica, Arial, sans-serif: Common font stack on OSX and Windows.
 
     */
-    font-family: FreeSans, Arimo, Helvetica, Arial, sans-serif;
+    font-family: FreeSans, Arimo, "Droid Sans", Helvetica, Arial, sans-serif;
 }
 
 /* Opera as of 12 on Windows needs word-spacing.

--- a/src/grids/css/grids-r.css
+++ b/src/grids/css/grids-r.css
@@ -18,10 +18,12 @@
     Arial` to get picked up by the browser, even though Helvetica or Arial
     isn't available in that environment.
 
+    * Droid Sans: Arch Linux with Chromium 29.x.
+
     * Helvetica, Arial, sans-serif: Common font stack on OSX and Windows.
 
     */
-    font-family: FreeSans, Arimo, Helvetica, Arial, sans-serif;
+    font-family: FreeSans, Arimo, "Droid Sans", Helvetica, Arial, sans-serif;
 }
 
 /* Opera as of 12 on Windows needs word-spacing.


### PR DESCRIPTION
- Remove "DejaVu Sans" since it doesn't work with the letter spacing.
- Replace "Bitstream Charter" with Freesans, a sans-serif alternative for Ubuntu.
- Replace Tinos with Arimo, a sans-serif alternative for Chrome OS.
