### PR TITLE
Same height for pure-button when using custom fonts

### DIFF
--- a/src/buttons/css/buttons.css
+++ b/src/buttons/css/buttons.css
@@ -1,6 +1,7 @@
 /*csslint unqualified-attributes:false, outline-none:false*/
 
 .pure-button {
+    font-family: inherit;
     font-size: 100%;
     *font-size: 90%; /*IE 6/7 - To reduce IE's oversized button text*/
     *overflow: visible; /*IE 6/7 - Because of IE's overly large left/right padding on buttons */

--- a/src/buttons/tests/manual/button.html
+++ b/src/buttons/tests/manual/button.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="../../../../build/buttons.css">
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.0.2/css/font-awesome.css">
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/3.0.2/css/font-awesome-ie7.css">
+    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 
     <style>
         .pure-button-green {
@@ -46,6 +47,10 @@
             background: #222;
             color: #fff;
             box-shadow: none;
+        }
+        
+        .custom-fonts {
+            font-family: 'Open Sans', sans-serif;
         }
     </style>
 </head>
@@ -111,5 +116,14 @@
         <input type="button" class="pure-button pure-button-primary" value="Input Button">
         <input type="reset" class="pure-button pure-button-primary" value="Reset">
     </p>
+
+    <h2>Primary Form Buttons (Custom Fonts)</h2>
+    <p class="custom-fonts">
+        <a class="pure-button pure-button-primary" href="#">Anchor</a>
+        <button class="pure-button pure-button-primary">Button</button>
+        <input type="submit" class="pure-button pure-button-primary" value="Submit">
+        <input type="button" class="pure-button pure-button-primary" value="Input Button">
+        <input type="reset" class="pure-button pure-button-primary" value="Reset">
+    </p>    
 </body>
 </html>


### PR DESCRIPTION
When using custom fonts, buttons (a and input) don't have the same
height (issue #221).
