### PR TITLE
Adds a Sized Button Test

### DIFF
--- a/src/forms/tests/manual/forms.html
+++ b/src/forms/tests/manual/forms.html
@@ -341,5 +341,17 @@
         <input type="button" class="pure-button pure-button-primary" value="Input Button" />
         <input type="reset" class="pure-button pure-button-primary" value="Reset" />
     </form>
+
+
+    <h2>Sized Buttons</h2>
+
+    <form class="pure-form">
+        <a class="pure-button pure-button-primary pure-input-1-3">Anchor</a><br><br>
+        <button class="pure-button pure-button-primary pure-input-1-3">Button</button><br><br>
+        <input type="submit" class="pure-button pure-button-primary pure-input-1-3" value="Submit" /><br><br>
+        <input type="button" class="pure-button pure-button-primary pure-input-1-3" value="Input Button" /><br><br>
+        <input type="reset" class="pure-button pure-button-primary pure-input-1-3" value="Reset" /><br><br>
+    </form>
+
 </body>
 </html>


### PR DESCRIPTION
This demonstrates the button sizing discrepancy reported in issue #271. Anchor buttons with explicit widths (`pure-input-1*`) contained in forms are too wide and break out of containing boxes. This seems to be a result of left and right padding being applied on top of the defined width.

The anchor button is too wide:

![screen shot 2014-01-12 at 10 45 07 am](https://f.cloud.github.com/assets/8320/1896462/4a5ee4ac-7ba1-11e3-827c-c7ae9a63af2c.png)

I'm putting this in a separate pull request from my proposed solution.
