### PR TITLE
Remove button/form transitions

### DIFF
--- a/src/buttons/css/buttons.css
+++ b/src/buttons/css/buttons.css
@@ -14,12 +14,6 @@
     background-color: #E6E6E6;
     text-decoration: none;
     border-radius: 2px;
-    /* Transitions */
-    -webkit-transition: 0.1s linear -webkit-box-shadow;
-    -moz-transition: 0.1s linear -moz-box-shadow;
-    -ms-transition: 0.1s linear box-shadow;
-    -o-transition: 0.1s linear box-shadow;
-    transition: 0.1s linear box-shadow;
 }
 
 .pure-button-hover,

--- a/src/forms/css/forms.css
+++ b/src/forms/css/forms.css
@@ -21,11 +21,6 @@
     font-size: 0.8em;
     box-shadow: inset 0 1px 3px #ddd;
     border-radius: 4px;
-    -webkit-transition: 0.3s linear border;
-    -moz-transition: 0.3s linear border;
-    -ms-transition: 0.3s linear border;
-    -o-transition: 0.3s linear border;
-    transition: 0.3s linear border;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;


### PR DESCRIPTION
They're annoying to override and probably don't belong in a bare-bones setup like Pure CSS.
