### PR TITLE
Reduce padding/add room on color input for Chrome (v32/34 OS X).

### DIFF
--- a/src/forms/css/forms.css
+++ b/src/forms/css/forms.css
@@ -26,6 +26,12 @@
     box-sizing: border-box;
 }
 
+/* Chrome (as of v.32/34 on OS X) needs additional room for color to display. */
+/* May be able to remove this tweak as color inputs become more standardized across browsers. */
+.pure-form input[type="color"] {
+    padding: 0.2em 0.5em;
+}
+
 .pure-form input:not([type]):focus,
 .pure-form input[type="text"]:focus,
 .pure-form input[type="password"]:focus,

--- a/src/forms/tests/manual/forms.html
+++ b/src/forms/tests/manual/forms.html
@@ -106,6 +106,9 @@
                 <option>NY</option>
             </select>
 
+            <label>Color</label>
+            <input type="color">
+
             <label class="pure-checkbox">
                 <input type="checkbox"> I've read the terms and conditions
             </label>


### PR DESCRIPTION
Result is slightly shorter (than other text fields) color input for legacy browsers, but it's probably worth it to have a better experience on supporting browsers.

Tested in Chrome, Firefox, & Safari.
