### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Optionally, you can build Pure from its source on Github. To do this, you'll
 need to have Node.js and npm installed. We use [Grunt][] to build Pure.
 
 ```shell
-$ git clone git@github.com:yui/pure.git
+$ git clone git@github.com/yui/pure.git
 $ cd pure
 $ npm install
 $ grunt


### PR DESCRIPTION
Fix syntax error in 'Build From Source' instructions. ':' replaced with '/'.
