### PR TITLE
Separate out `:not()` selectors from CSS 2.1 selectors.

### DIFF
--- a/src/forms/css/forms.css
+++ b/src/forms/css/forms.css
@@ -57,8 +57,7 @@ since IE8 won't execute CSS that contains a CSS3 selector.
 .pure-form input[type="tel"]:focus,
 .pure-form input[type="color"]:focus,
 .pure-form select:focus,
-.pure-form textarea:focus
- {
+.pure-form textarea:focus {
     outline: 0;
     outline: thin dotted \9; /* IE6-9 */
     border-color: #129FEA;


### PR DESCRIPTION
IE8 won't execute the CSS block if it contains a CSS3 selector.
This makes IE8 still execute the CSS, and CSS3-compliant browsers
can support the `:not()`.
