### PR TITLE
Do not force border-width on invalid form inputs

### DIFF
--- a/src/forms/css/forms.css
+++ b/src/forms/css/forms.css
@@ -132,7 +132,7 @@ since IE8 won't execute CSS that contains a CSS3 selector.
 .pure-form textarea:focus:invalid,
 .pure-form select:focus:invalid {
     color: #b94a48;
-    border: 1px solid #ee5f5b;
+    border-color: #ee5f5b;
 }
 .pure-form input:focus:invalid:focus,
 .pure-form textarea:focus:invalid:focus,


### PR DESCRIPTION
I have set border-width on on my inputs and it is overridden by that declaration.
