### PR TITLE
Add block wide expanded button class.

### DIFF
--- a/src/buttons/css/buttons.css
+++ b/src/buttons/css/buttons.css
@@ -65,3 +65,31 @@ a.pure-button-selected {
     background-color: rgb(0, 120, 231);
     color: #fff;
 }
+
+.pure-button-expanded {
+    width: 100%;
+}
+
+@media screen and (max-width: 35.5em) {
+    .pure-button-sm-expanded {
+        width: 100%;
+    }
+}
+
+@media screen and (max-width: 48em) {
+    .pure-button-md-expanded {
+        width: 100%;
+    }
+}
+
+@media screen and (max-width: 64em) {
+    .pure-button-lg-expanded {
+        width: 100%;
+    }
+}
+
+@media screen and (max-width: 80em) {
+    .pure-button-xl-expanded {
+        width: 100%;
+    }
+}

--- a/src/buttons/tests/manual/button.html
+++ b/src/buttons/tests/manual/button.html
@@ -48,7 +48,7 @@
             color: #fff;
             box-shadow: none;
         }
-        
+
         .custom-fonts {
             font-family: 'Open Sans', sans-serif;
         }
@@ -124,6 +124,14 @@
         <input type="submit" class="pure-button pure-button-primary" value="Submit">
         <input type="button" class="pure-button pure-button-primary" value="Input Button">
         <input type="reset" class="pure-button pure-button-primary" value="Reset">
-    </p>    
+    </p>
+
+    <h2>Block wide expanded button</h2>
+    <button class="pure-button pure-button-expanded">Always Expanded Button</button>
+    <button class="pure-button pure-button-sm-expanded">Expanded on max small screens Button</button>
+    <button class="pure-button pure-button-md-expanded">Expanded on max md screens Button</button>
+    <button class="pure-button pure-button-lg-expanded">Expanded on max lg screens Button</button>
+    <button class="pure-button pure-button-xl-expanded">Expanded on max xl screens Button</button>
+    
 </body>
 </html>


### PR DESCRIPTION
This is an example implementation for the #585. It adds the following classes:

`.pure-button-expanded`
`pure-button-sm-expanded`
`pure-button-md-expanded`
`pure-button-lg-expanded`
`pure-button-xl-expanded`

It would be very important to note here that the responsive classes works the _opposite way_ grid does. The case here, is a button to be expanded in smaller screens and normal in larger. So for example `pure-button-sm-expanded` has `@media screen and (max-width: 35.5em)` media query, which implements the behaviour described above.

What do you guys think?
