### PR TITLE
Removed white-space:nowrap

### DIFF
--- a/src/menus/css/menus-horizontal.css
+++ b/src/menus/css/menus-horizontal.css
@@ -1,7 +1,6 @@
 /* HORIZONTAL MENU */
 .pure-menu-horizontal {
     width: 100%;
-    white-space: nowrap;
 }
 
 .pure-menu-horizontal .pure-menu-list {


### PR DESCRIPTION
This line breaks layout on Mozilla Firefox and does not really help anywhere else.
See https://github.com/yahoo/pure/issues/644
