### PR TITLE
Removing font specific settings from Grid and Button.

### DIFF
--- a/src/buttons/css/buttons-core.css
+++ b/src/buttons/css/buttons-core.css
@@ -17,23 +17,3 @@
     padding: 0;
     border: 0;
 }
-
-/* Inherit .pure-g styles */
-.pure-button-group {
-    letter-spacing: -0.31em; /* Webkit: collapse white-space between units */
-    *letter-spacing: normal; /* reset IE < 8 */
-    *word-spacing: -0.43em; /* IE < 8: collapse white-space between units */
-    text-rendering: optimizespeed; /* Webkit: fixes text-rendering: optimizeLegibility */
-}
-
-.opera-only :-o-prefocus,
-.pure-button-group {
-    word-spacing: -0.43em;
-}
-
-.pure-button-group .pure-button {
-    letter-spacing: normal;
-    word-spacing: normal;
-    vertical-align: top;
-    text-rendering: auto;
-}

--- a/src/buttons/css/buttons.css
+++ b/src/buttons/css/buttons.css
@@ -1,7 +1,6 @@
 /*csslint outline-none:false*/
 
 .pure-button {
-    font-family: inherit;
     font-size: 100%;
     padding: 0.5em 1em;
     color: #444; /* rgba not supported (IE 8) */

--- a/src/grids/css/grids-core.css
+++ b/src/grids/css/grids-core.css
@@ -1,30 +1,7 @@
 /*csslint regex-selectors:false, known-properties:false, duplicate-properties:false*/
 
 .pure-g {
-    letter-spacing: -0.31em; /* Webkit: collapse white-space between units */
-    *letter-spacing: normal; /* reset IE < 8 */
-    *word-spacing: -0.43em; /* IE < 8: collapse white-space between units */
-    text-rendering: optimizespeed; /* Webkit: fixes text-rendering: optimizeLegibility */
-
-    /*
-    Sets the font stack to fonts known to work properly with the above letter
-    and word spacings. See: https://github.com/pure-css/pure/issues/41/
-
-    The following font stack makes Pure Grids work on all known environments.
-
-    * FreeSans: Ships with many Linux distros, including Ubuntu
-
-    * Arimo: Ships with Chrome OS. Arimo has to be defined before Helvetica and
-      Arial to get picked up by the browser, even though neither is available
-      in Chrome OS.
-
-    * Droid Sans: Ships with all versions of Android.
-
-    * Helvetica, Arial, sans-serif: Common font stack on OS X and Windows.
-    */
-    font-family: FreeSans, Arimo, "Droid Sans", Helvetica, Arial, sans-serif;
-
-    /* Use flexbox when possible to avoid `letter-spacing` side-effects. */
+/* Use flexbox when possible to avoid `letter-spacing` side-effects. */
     display: flex;
     flex-flow: row wrap;
 
@@ -39,29 +16,8 @@
 	}
 }
 
-/* Opera as of 12 on Windows needs word-spacing.
-   The ".opera-only" selector is used to prevent actual prefocus styling
-   and is not required in markup.
-*/
-.opera-only :-o-prefocus,
-.pure-g {
-    word-spacing: -0.43em;
-}
-
 .pure-u {
     display: inline-block;
     *display: inline; /* IE < 8: fake inline-block */
     zoom: 1;
-    letter-spacing: normal;
-    word-spacing: normal;
-    vertical-align: top;
-    text-rendering: auto;
-}
-
-/*
-Resets the font family back to the OS/browser's default sans-serif font,
-this the same font stack that Normalize.css sets for the `body`.
-*/
-.pure-g [class *= "pure-u"] {
-    font-family: sans-serif;
 }


### PR DESCRIPTION
Please remove font related settings from purecss. Instead you can provide an optional file to set those details for those who are interested. Adding those font families by default is a conflict with the name pure.