### PR TITLE
Fix issue #458 - Horizontal scrollbars not appearing in IE11 and Chrome for pure-menu-scrollable

### DIFF
--- a/src/menus/css/menus-scrollable.css
+++ b/src/menus/css/menus-scrollable.css
@@ -16,12 +16,7 @@
     white-space: nowrap;
     overflow-y: hidden;
     overflow-x: auto;
-    -ms-overflow-style: none;
     -webkit-overflow-scrolling: touch;
     /* a little extra padding for this style to allow for scrollbars */
     padding: .5em 0;
-}
-
-.pure-menu-horizontal.pure-menu-scrollable::-webkit-scrollbar {
-    display: none;
 }


### PR DESCRIPTION
Fixes #458.

Tested on Windows 7 x64 in:
IE11 11.0.96 (latest) (fixed)
Firefox 67.0.2 (no change)
Chrome 75.0 (fixed)

It would need additional tests on mobile.