### PR TITLE
fix: docusaurus links

### DIFF
--- a/site/components/Footer.js
+++ b/site/components/Footer.js
@@ -1,19 +1,19 @@
 import React from 'react';
 
 function Footer({ siteConfig }) {
-    const { customFields, organizationName, projectName } = siteConfig;
+    const { customFields, organizationName } = siteConfig;
     return (
         <div className="footer">
             <div className="legal pure-g">
                 <div className="pure-u-1 u-sm-1-2">
                     <p className="legal-license">
                         This site is built with ❤️ using Pure v{customFields.pureVersion}<br />
-                        All code on this site is licensed under the <a href={`https://github.com/${organizationName}/${projectName}/blob/master/LICENSE`}>Yahoo BSD License</a> unless otherwise stated.
+                        All code on this site is licensed under the <a href={`https://github.com/${organizationName}/${customFields.repoName}/blob/master/LICENSE`}>Yahoo BSD License</a> unless otherwise stated.
                     </p>
                 </div>
                 <div className="pure-u-1 u-sm-1-2">
                     <ul className="legal-links">
-                        <li><a href={`https://github.com/${organizationName}/${projectName}/`}>GitHub Project</a></li>
+                        <li><a href={`https://github.com/${organizationName}/${customFields.repoName}/`}>GitHub Project</a></li>
                         <li><a href="https://hackerone.com/yahoo/">Security Contact Info</a></li>
                     </ul>
                     <p className="legal-copyright">

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -23,5 +23,6 @@ module.exports = {
         PURE_DOWNLOAD_SNIPPET,
         moduleSizes: moduleSizes(),
         pureVersion: version,
+        repoName: 'pure',
     },
 };

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -28,9 +28,9 @@ function Home() {
         customFields: {
             moduleSizes,
             PURE_DOWNLOAD_SNIPPET,
+            repoName,
         },
         organizationName,
-        projectName,
     } = siteConfig;
     const renderSize = renderModuleSize(moduleSizes);
     return (
@@ -47,7 +47,7 @@ function Home() {
 
                     <p>
                         <Link className="button-cta pure-button" to="/start/">Get Started</Link>
-                        <a className="button-secondary pure-button" href={`https://github.com/${organizationName}/${projectName}/`}>View on GitHub</a>
+                        <a className="button-secondary pure-button" href={`https://github.com/${organizationName}/${repoName}/`}>View on GitHub</a>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
The links in the footer (and the one on index) lead to files in the github.io page rather than this repo.
Unless I am wrong, they should redirect to this repo.

This PR changes `projectName` in `docusaurus.config.js` from `pure-css.github.io` to `pure`.

If I am wrong, then the license url on the footer leads to a LICENSE that doesn't exist: https://github.com/pure-css/pure/blob/9dc1a9ddcf98ef61d655b448f11367a04f96fa92/site/components/Footer.js#L11 (https://github.com/pure-css/pure-css.github.io/blob/master/LICENSE)

If I am not wrong but changing `projectName` in `docusaurus.config.js` is out of the question, then in the following lines `${projectName}` could change to a static `pure`:

- https://github.com/pure-css/pure/blob/9dc1a9ddcf98ef61d655b448f11367a04f96fa92/site/components/Footer.js#L11
- https://github.com/pure-css/pure/blob/9dc1a9ddcf98ef61d655b448f11367a04f96fa92/site/components/Footer.js#L16
- https://github.com/pure-css/pure/blob/9dc1a9ddcf98ef61d655b448f11367a04f96fa92/site/src/pages/index.js#L50