### PR TITLE
docs: switch cdn from unpkg to jsdelivr

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -76,13 +76,13 @@ This assumes the following repo's are cloned and `npm` installed:
 
 ## Publish pure to NPM
 
-From the `pure` repo run the following command to publish Pure to NPM. This will ensure `unpkg.com` CDN gets the new files.
+From the `pure` repo run the following command to publish Pure to NPM. This will ensure `jsdelivr.com` CDN gets the new files.
 
 ```bash
 npm publish .
 ```
 
-Verify via https://unpkg.com/purecss@VERSION
+Verify via https://www.jsdelivr.com/package/npm/purecss
 
 ## Draft releases on Github
 

--- a/site/lib/pure.js
+++ b/site/lib/pure.js
@@ -10,10 +10,10 @@ const pureFiles = path.resolve(pureDir, 'build');
 const pureMin = fs.readFileSync(path.resolve(pureFiles, 'pure-min.css'), 'utf8');
 
 // use pure-min.css to determine site integrity hash
-const sriHash = crypto.createHash('sha384').update(pureMin, 'utf8').digest('base64');
+const sriHash = crypto.createHash('sha256').update(pureMin, 'utf8').digest('base64');
 
 // copy/pastable code snippet for users
-module.exports.PURE_DOWNLOAD_SNIPPET = `<link rel="stylesheet" href="https://unpkg.com/purecss@${version}/build/pure-min.css" integrity="sha384-${sriHash}" crossorigin="anonymous">`;
+module.exports.PURE_DOWNLOAD_SNIPPET = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@${version}/build/pure-min.css" integrity="sha256-${sriHash}" crossorigin="anonymous">`;
 
 // calculate each pure module size
 module.exports.moduleSizes = function moduleSizes() {

--- a/site/lib/pure.js
+++ b/site/lib/pure.js
@@ -10,10 +10,10 @@ const pureFiles = path.resolve(pureDir, 'build');
 const pureMin = fs.readFileSync(path.resolve(pureFiles, 'pure-min.css'), 'utf8');
 
 // use pure-min.css to determine site integrity hash
-const sriHash = crypto.createHash('sha256').update(pureMin, 'utf8').digest('base64');
+const sriHash = crypto.createHash('sha384').update(pureMin, 'utf8').digest('base64');
 
 // copy/pastable code snippet for users
-module.exports.PURE_DOWNLOAD_SNIPPET = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@${version}/build/pure-min.css" integrity="sha256-${sriHash}" crossorigin="anonymous">`;
+module.exports.PURE_DOWNLOAD_SNIPPET = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@${version}/build/pure-min.css" integrity="sha384-${sriHash}" crossorigin="anonymous">`;
 
 // calculate each pure module size
 module.exports.moduleSizes = function moduleSizes() {

--- a/site/src/pages/base/index.js
+++ b/site/src/pages/base/index.js
@@ -9,6 +9,14 @@ const title = 'Base';
 const description = 'Leveraging Normalize.css, an HTML5-ready alternative to CSS resets.';
 
 function Base() {
+    const context = useDocusaurusContext();
+    const {siteConfig = {}} = context;
+    const {
+        customFields: {
+            pureVersion,
+        },
+    } = siteConfig;
+
     return (
         <Layout description={description} title={title}>
             <Header description={description} title={title} />
@@ -21,7 +29,7 @@ function Base() {
                 </p>
 
                 <CodeBlock wrap={true}>
-                    {'<link rel="stylesheet" href="https://unpkg.com/purecss@1.0.1/build/base-min.css">'}
+                    {`<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@${pureVersion}/build/base-min.css">`}
                 </CodeBlock>
 
                 <h3>A bit about Normalize.css</h3>

--- a/site/src/pages/base/index.js
+++ b/site/src/pages/base/index.js
@@ -1,4 +1,5 @@
 import Link from '@docusaurus/Link';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import React from 'react';
 import Layout from '../../theme/Layout';
 import Header from '../../../components/Header';

--- a/site/src/pages/customize/index.js
+++ b/site/src/pages/customize/index.js
@@ -42,12 +42,12 @@ function Customize() {
                         <tbody>
                             <tr>
                                 <td>Responsive Rollup</td>
-                                <td>https://unpkg.com/purecss@{pureVersion}/build/pure-min.css</td>
+                                <td>https://cdn.jsdelivr.net/npm/purecss@{pureVersion}/build/pure-min.css</td>
                                 <td>{fileSize({ module: 'pure', filesizes })}</td>
                             </tr>
                             <tr>
                                 <td>Non-Responsive Rollup</td>
-                                <td>https://unpkg.com/purecss@{pureVersion}/build/pure-nr-min.css</td>
+                                <td>https://cdn.jsdelivr.net/npm/purecss@{pureVersion}/build/pure-nr-min.css</td>
                                 <td>{fileSize({ module: 'pure-nr', filesizes })}</td>
                             </tr>
                         </tbody>
@@ -63,7 +63,7 @@ function Customize() {
                 <h3>Alternate CDNs</h3>
 
                 <p>
-                    The main host for Pure is the unpkg CDN where Pure is available over HTTPS. The following table lists alternate CDNs where Pure is hosted.
+                    The main host for Pure is the jsDelivr CDN where Pure is available over HTTPS. The following table lists alternate CDNs where Pure is hosted.
                 </p>
 
                 <div className="table-responsive">
@@ -132,35 +132,35 @@ function Customize() {
                         <tbody>
                             <tr>
                                 <td>Base</td>
-                                <td>https://unpkg.com/purecss@{pureVersion}/build/base-min.css</td>
+                                <td>https://cdn.jsdelivr.net/npm/purecss@{pureVersion}/build/base-min.css</td>
                             </tr>
                             <tr>
                                 <td>Buttons</td>
-                                <td>https://unpkg.com/purecss@{pureVersion}/build/buttons-min.css</td>
+                                <td>https://cdn.jsdelivr.net/npm/purecss@{pureVersion}/build/buttons-min.css</td>
                             </tr>
                             <tr>
                                 <td>Forms (Responsive)</td>
-                                <td>https://unpkg.com/purecss@{pureVersion}/build/forms-min.css</td>
+                                <td>https://cdn.jsdelivr.net/npm/purecss@{pureVersion}/build/forms-min.css</td>
                             </tr>
                             <tr>
                                 <td>Forms (Non-Responsive)</td>
-                                <td>https://unpkg.com/purecss@{pureVersion}/build/forms-nr-min.css</td>
+                                <td>https://cdn.jsdelivr.net/npm/purecss@{pureVersion}/build/forms-nr-min.css</td>
                             </tr>
                             <tr>
                                 <td>Grids (Base)</td>
-                                <td>https://unpkg.com/purecss@{pureVersion}/build/grids-min.css</td>
+                                <td>https://cdn.jsdelivr.net/npm/purecss@{pureVersion}/build/grids-min.css</td>
                             </tr>
                             <tr>
                                 <td>Grids (Responsive)</td>
-                                <td>https://unpkg.com/purecss@{pureVersion}/build/grids-responsive-min.css</td>
+                                <td>https://cdn.jsdelivr.net/npm/purecss@{pureVersion}/build/grids-responsive-min.css</td>
                             </tr>
                             <tr>
                                 <td>Menus (Responsive)</td>
-                                <td>https://unpkg.com/purecss@{pureVersion}/build/menus-min.css</td>
+                                <td>https://cdn.jsdelivr.net/npm/purecss@{pureVersion}/build/menus-min.css</td>
                             </tr>
                             <tr>
                                 <td>Tables</td>
-                                <td>https://unpkg.com/purecss@{pureVersion}/build/tables-min.css</td>
+                                <td>https://cdn.jsdelivr.net/npm/purecss@{pureVersion}/build/tables-min.css</td>
                             </tr>
                         </tbody>
                     </table>
@@ -169,7 +169,7 @@ function Customize() {
                 <SectionHeader heading="Combo Handling" />
 
                 <p>
-                    jsDelivr is a CDN that supports combo handling. Here's an example of a combo URL that includes the same CSS <a href="/base/">Base</a>, <a href="/grids/">Grids</a>, and <a href="/forms/">Forms</a> as above.
+                    jsDelivr is also a CDN that supports combo handling. Here's an example of a combo URL that includes the same CSS <a href="/base/">Base</a>, <a href="/grids/">Grids</a>, and <a href="/forms/">Forms</a> as above.
                 </p>
 
                 <CodeBlock>

--- a/site/src/pages/grids/index.js
+++ b/site/src/pages/grids/index.js
@@ -481,7 +481,7 @@ function Grids() {
                 </p>
 
                 <CodeBlock>
-                    {`<link rel="stylesheet" href="https://unpkg.com/purecss@${pureVersion}/build/grids-responsive-min.css" />`}
+                    {`<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@${pureVersion}/build/grids-responsive-min.css" />`}
                 </CodeBlock>
 
                 <h3>Pure's Regular Grid vs. Responsive Grid</h3>
@@ -824,9 +824,9 @@ function Grids() {
 
                 <CodeBlock>
                     {stripIndent`
-                        <link rel="stylesheet" href="https://unpkg.com/purecss@${pureVersion}/build/base-min.css">
-                        <link rel="stylesheet" href="https://unpkg.com/purecss@${pureVersion}/build/grids-min.css">
-                        <link rel="stylesheet" href="https://unpkg.com/purecss@${pureVersion}/build/grids-responsive-min.css">
+                        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@${pureVersion}/build/base-min.css">
+                        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@${pureVersion}/build/grids-min.css">
+                        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@${pureVersion}/build/grids-responsive-min.css">
                     `}
                 </CodeBlock>
 

--- a/site/src/pages/start/index.js
+++ b/site/src/pages/start/index.js
@@ -27,7 +27,7 @@ function Start() {
                 <SectionHeader heading="Add Pure to Your Page" />
 
                 <p>
-                  You can add Pure to your page via the <b>free unpkg CDN</b>. Just add the following <code>&lt;link&gt;</code> element into your page's <code>&lt;head&gt;</code>, before your project's stylesheets.
+                  You can add Pure to your page via the <b>free jsDelivr CDN</b>. Just add the following <code>&lt;link&gt;</code> element into your page's <code>&lt;head&gt;</code>, before your project's stylesheets.
                 </p>
             </div>
 
@@ -100,7 +100,7 @@ function Start() {
                 </p>
 
                 <CodeBlock wrap={true}>
-                    {`<link rel="stylesheet" href="https://unpkg.com/purecss@${pureVersion}/build/grids-responsive-min.css">`}
+                    {`<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@${pureVersion}/build/grids-responsive-min.css">`}
                 </CodeBlock>
 
                 <p>
@@ -318,7 +318,7 @@ function Start() {
 
                                   &lt;title&gt;Your page title&lt;/title&gt;
 
-                                  &lt;link rel&#x3D;&quot;stylesheet&quot; href&#x3D;&quot;https://unpkg.com/purecss@1.0.1/build/pure-min.css&quot;&gt;&lt;/head&gt;
+                                  &lt;link rel&#x3D;&quot;stylesheet&quot; href&#x3D;&quot;https://cdn.jsdelivr.net/npm/purecss@1.0.1/build/pure-min.css&quot;&gt;&lt;/head&gt;
 
                               &lt;body&gt;
                                   &lt;!--


### PR DESCRIPTION
Closes #1033. Also applied a small fix to `pages/base/index.js` where the CDN version links weren't being updated automatically since the DocusaurausContext loader wasn't being used.