### PR TITLE
Added media queries for 2.5K and 4K screens

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -203,8 +203,9 @@ module.exports = function (grunt) {
                         md: 'screen and (min-width: 48em)',     // 768px
                         lg: 'screen and (min-width: 64em)',     // 1024px
                         xl: 'screen and (min-width: 80em)',     // 1280px
-                        xxl: 'screen and (min-width: 120em)'    // 1920px
-                        xxxl: 'screen and (min-width: 160em)'    // 2560px
+                        xxl: 'screen and (min-width: 120em)',    // 1920px
+                        xxxl: 'screen and (min-width: 160em)',    // 2560px
+                        x4k: 'screen and (min-width: 240em)'    // 3840px
                     }
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -204,6 +204,7 @@ module.exports = function (grunt) {
                         lg: 'screen and (min-width: 64em)',     // 1024px
                         xl: 'screen and (min-width: 80em)',     // 1280px
                         xxl: 'screen and (min-width: 120em)'    // 1920px
+                        xxxl: 'screen and (min-width: 160em)'    // 2560px
                     }
                 }
             }

--- a/site/src/pages/grids/index.js
+++ b/site/src/pages/grids/index.js
@@ -571,8 +571,15 @@ function Grids() {
                                 <td className="highlight"><b><code>xxxl</code></b></td>
                                 <td className="mq-table-mq highlight"><code>@media screen and (min-width: 160em)</code></td>
                                 <td>≥ <b>2560px</b></td>
-                                <td><code>.pure-u-<b>xxl</b>-*</code></td>
+                                <td><code>.pure-u-<b>xxxl</b>-*</code></td>
                             </tr>
+                            <tr>
+                                <td className="highlight"><b><code>x4k</code></b></td>
+                                <td className="mq-table-mq highlight"><code>@media screen and (min-width: 240em)</code></td>
+                                <td>≥ <b>3840px</b></td>
+                                <td><code>.pure-u-<b>x4k</b>-*</code></td>
+                            </tr>
+
                         </tbody>
                     </table>
                 </div>

--- a/site/src/pages/grids/index.js
+++ b/site/src/pages/grids/index.js
@@ -567,6 +567,12 @@ function Grids() {
                                 <td>≥ <b>1920px</b></td>
                                 <td><code>.pure-u-<b>xxl</b>-*</code></td>
                             </tr>
+                            <tr>
+                                <td className="highlight"><b><code>xxxl</code></b></td>
+                                <td className="mq-table-mq highlight"><code>@media screen and (min-width: 160em)</code></td>
+                                <td>≥ <b>2560px</b></td>
+                                <td><code>.pure-u-<b>xxl</b>-*</code></td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/site/src/pages/start/index.js
+++ b/site/src/pages/start/index.js
@@ -154,6 +154,12 @@ function Start() {
                                 <td>≥ <b>1920px</b></td>
                                 <td><code>.pure-u-<b>xxl</b>-*</code></td>
                             </tr>
+                            <tr>
+                                <td className="highlight"><b><code>xxxl</code></b></td>
+                                <td className="mq-table-mq highlight"><code>@media screen and (min-width: 160em)</code></td>
+                                <td>≥ <b>2560px</b></td>
+                                <td><code>.pure-u-<b>xxxl</b>-*</code></td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/site/src/pages/start/index.js
+++ b/site/src/pages/start/index.js
@@ -160,6 +160,12 @@ function Start() {
                                 <td>≥ <b>2560px</b></td>
                                 <td><code>.pure-u-<b>xxxl</b>-*</code></td>
                             </tr>
+                            <tr>
+                                <td className="highlight"><b><code>x4k</code></b></td>
+                                <td className="mq-table-mq highlight"><code>@media screen and (min-width: 240em)</code></td>
+                                <td>≥ <b>3840px</b></td>
+                                <td><code>.pure-u-<b>x4k</b>-*</code></td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/site/src/pages/tools/index.js
+++ b/site/src/pages/tools/index.js
@@ -131,6 +131,7 @@ function Tools() {
                             lg: 'screen and (min-width: 64em)',   // 1024px
                             xl: 'screen and (min-width: 80em)',   // 1280px
                             xxl: 'screen and (min-width: 120em)'  // 1920px
+                            xxxl: 'screen and (min-width: 160em)'  // 2560px
                         }
                     })).toString();
 

--- a/site/src/pages/tools/index.js
+++ b/site/src/pages/tools/index.js
@@ -95,8 +95,9 @@ function Tools() {
                                     md: 'screen and (min-width: 48em)',   // 768px
                                     lg: 'screen and (min-width: 64em)',   // 1024px
                                     xl: 'screen and (min-width: 80em)',   // 1280px
-                                    xxl: 'screen and (min-width: 120em)'  // 1920px
-                                    xxxl: 'screen and (min-width: 160em)'  // 2560px                                    
+                                    xxl: 'screen and (min-width: 120em)',  // 1920px
+                                    xxxl: 'screen and (min-width: 160em)',  // 2560px                                    
+                                    x4k: 'screen and (min-width: 240em)'  // 3840px                                    
                                 }
                             }
                         }
@@ -131,8 +132,9 @@ function Tools() {
                             md: 'screen and (min-width: 48em)',   // 768px
                             lg: 'screen and (min-width: 64em)',   // 1024px
                             xl: 'screen and (min-width: 80em)',   // 1280px
-                            xxl: 'screen and (min-width: 120em)'  // 1920px
+                            xxl: 'screen and (min-width: 120em)',  // 1920px
                             xxxl: 'screen and (min-width: 160em)'  // 2560px
+                            x4k: 'screen and (min-width: 240em)'  // 3840px
                         }
                     })).toString();
 

--- a/site/src/pages/tools/index.js
+++ b/site/src/pages/tools/index.js
@@ -96,6 +96,7 @@ function Tools() {
                                     lg: 'screen and (min-width: 64em)',   // 1024px
                                     xl: 'screen and (min-width: 80em)',   // 1280px
                                     xxl: 'screen and (min-width: 120em)'  // 1920px
+                                    xxxl: 'screen and (min-width: 160em)'  // 2560px                                    
                                 }
                             }
                         }


### PR DESCRIPTION
When building a page with a grid of cards, if the layout takes up the full width of the screen, there are significant differences between FHD, QHD, and 4K screens. What looks good on a FHD screen, can look either sparse or stretched out on a QHD/4K screen. 

So I extended it to include 2.5K (`xxxl`) and 4K (`x4k`) media queries. 

I use it from the local directory but it'd be better to have it over the CDN, so others can use it also. 