### PR TITLE
#1143 Off-Canvas changed to Fly-Out menu

### DIFF
--- a/site/static/css/main.css
+++ b/site/static/css/main.css
@@ -590,18 +590,6 @@ a.pure-button-primary {
 
 }
 
-@media (max-width: 58em) {
-    /* Only apply this when the window is smaller. Otherwise, the following
-    case results in extra padding on the left:
-        * Make the window small. (Rotate to portrait on a mobile.)
-        * Tap the menu to trigger the active state.
-        * Make the window large again. (Rotate to landscape on mobile.)
-    */
-    #layout.active {
-        position: relative;
-    }
-}
-
 @media (min-width: 58em) {
 
     #layout {

--- a/site/static/css/main.css
+++ b/site/static/css/main.css
@@ -599,7 +599,6 @@ a.pure-button-primary {
     */
     #layout.active {
         position: relative;
-        left: 160px;
     }
 }
 

--- a/site/static/layouts/side-menu/styles.css
+++ b/site/static/layouts/side-menu/styles.css
@@ -243,6 +243,5 @@ Hides the menu at `48em`, but modify this based on your app's needs.
     */
     #layout.active {
         position: relative;
-        left: 150px;
     }
 }

--- a/site/static/layouts/side-menu/styles.css
+++ b/site/static/layouts/side-menu/styles.css
@@ -233,15 +233,3 @@ Hides the menu at `48em`, but modify this based on your app's needs.
         left: 150px;
     }
 }
-
-@media (max-width: 48em) {
-    /* Only apply this when the window is small. Otherwise, the following
-    case results in extra padding on the left:
-        * Make the window small.
-        * Tap the menu to trigger the active state.
-        * Make the window large again.
-    */
-    #layout.active {
-        position: relative;
-    }
-}


### PR DESCRIPTION
Fix for #1143

This PR changes the side menu from off-canvas to fly-out on the mobile view.

It was only tested with the developer tools in Chromium version 120.0.6099.199 (official build) Arch Linux (64-bit).

Please check with other environments. 
Thank you very much.

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
