### PR TITLE
docs: fix Composer package name on tools page

### DIFF
--- a/site/src/pages/tools/index.js
+++ b/site/src/pages/tools/index.js
@@ -39,7 +39,7 @@ function Tools() {
                 You can also install Pure with <a href="https://getcomposer.org/">Composer</a>.
                 </p>
 
-                <CodeBlock>$ composer require pure-css/pure</CodeBlock>
+                <CodeBlock>$ composer require yahoo/purecss</CodeBlock>
 
                 <SectionHeader heading="Extending Pure with Grunt" />
 


### PR DESCRIPTION
## Summary
- The tools page told users to run `composer require pure-css/pure`, which is not published on Packagist.
- Update the snippet to `composer require yahoo/purecss`, which installs successfully.

Fixes #1422

## Test plan
- [ ] Confirm Packagist lists `yahoo/purecss`
- [ ] Confirm `composer require yahoo/purecss` works in a fresh directory
- [ ] Confirm the tools page snippet matches the updated command